### PR TITLE
In order for better print debug level, the Trace print now be

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -236,7 +236,7 @@ func (cl *ClientImpl) GetAccountByKeyHash(publicKeyHash Uint160) *Account {
 }
 
 func (cl *ClientImpl) GetAccountByProgramHash(programHash Uint160) *Account {
-	log.Trace()
+	log.Debug()
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
 
@@ -247,7 +247,7 @@ func (cl *ClientImpl) GetAccountByProgramHash(programHash Uint160) *Account {
 }
 
 func (cl *ClientImpl) GetContract(codeHash Uint160) *ct.Contract {
-	log.Trace()
+	log.Debug()
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
 	//fmt.Println("codeHash",codeHash)
@@ -381,7 +381,7 @@ func (cl *ClientImpl) ProcessNewBlock(block *ledger.Block) {
 }
 
 func (cl *ClientImpl) Sign(context *ct.ContractContext) bool {
-	log.Trace()
+	log.Debug()
 	fSuccess := false
 	for i, hash := range context.ProgramHashes {
 		//fmt.Println("Sign hash=",hash)

--- a/common/common.go
+++ b/common/common.go
@@ -29,7 +29,7 @@ func ToCodeHash(code []byte) (Uint160, error) {
 }
 
 func GetNonce() uint64 {
-	log.Trace()
+	log.Debug()
 	// Fixme replace with the real random number generator
 	nonce := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
 	return nonce

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -41,12 +41,12 @@ const (
 
 var (
 	levels = map[int]string{
-		traceLog: Color(Pink, "[TRACE]"),
 		debugLog: Color(Green, "[DEBUG]"),
 		infoLog:  Color(Green, "[INFO ]"),
 		warnLog:  Color(Yellow, "[WARN ]"),
 		errorLog: Color(Red, "[ERROR]"),
 		fatalLog: Color(Red, "[FATAL]"),
+		traceLog: Color(Pink, "[TRACE]"),
 	}
 )
 
@@ -172,11 +172,15 @@ func Trace(a ...interface{}) {
 	file, line := f.FileLine(pc[0])
 	fileName := filepath.Base(file)
 	Log.Trace(fmt.Sprint(f.Name(), " ", fileName, ":", line, " ", fmt.Sprint(a...)))
-
 }
 
 func Debug(a ...interface{}) {
-	Log.Debug(fmt.Sprint(a...))
+	pc := make([]uintptr, 10)
+	runtime.Callers(2, pc)
+	f := runtime.FuncForPC(pc[0])
+	file, line := f.FileLine(pc[0])
+	fileName := filepath.Base(file)
+	Log.Debug(fmt.Sprint(f.Name(), " ", fileName, ":", line, " ", fmt.Sprint(a...)))
 }
 
 func Info(a ...interface{}) {

--- a/consensus/dbft/consensusContext.go
+++ b/consensus/dbft/consensusContext.go
@@ -41,17 +41,17 @@ type ConsensusContext struct {
 }
 
 func (cxt *ConsensusContext) M() int {
-	log.Trace()
+	log.Debug()
 	return len(cxt.Miners) - (len(cxt.Miners)-1)/3
 }
 
 func NewConsensusContext() *ConsensusContext {
-	log.Trace()
+	log.Debug()
 	return &ConsensusContext{}
 }
 
 func (cxt *ConsensusContext) ChangeView(viewNum byte) {
-	log.Trace()
+	log.Debug()
 	p := (cxt.Height - uint32(viewNum)) % uint32(len(cxt.Miners))
 	cxt.State &= SignatureSent
 	cxt.ViewNumber = viewNum
@@ -69,7 +69,7 @@ func (cxt *ConsensusContext) ChangeView(viewNum byte) {
 }
 
 func (cxt *ConsensusContext) HasTxHash(txHash Uint256) bool {
-	log.Trace()
+	log.Debug()
 	for _, hash := range cxt.TransactionHashes {
 		if hash == txHash {
 			return true
@@ -79,7 +79,7 @@ func (cxt *ConsensusContext) HasTxHash(txHash Uint256) bool {
 }
 
 func (cxt *ConsensusContext) MakeChangeView() *msg.ConsensusPayload {
-	log.Trace()
+	log.Debug()
 	cv := &ChangeView{
 		NewViewNumber: cxt.ExpectedView[cxt.MinerIndex],
 	}
@@ -88,7 +88,7 @@ func (cxt *ConsensusContext) MakeChangeView() *msg.ConsensusPayload {
 }
 
 func (cxt *ConsensusContext) MakeHeader() *ledger.Block {
-	log.Trace()
+	log.Debug()
 	if cxt.TransactionHashes == nil {
 		return nil
 	}
@@ -114,7 +114,7 @@ func (cxt *ConsensusContext) MakeHeader() *ledger.Block {
 }
 
 func (cxt *ConsensusContext) MakePayload(message ConsensusMessage) *msg.ConsensusPayload {
-	log.Trace()
+	log.Debug()
 	message.ConsensusMessageData().ViewNumber = cxt.ViewNumber
 	return &msg.ConsensusPayload{
 		Version:    ContextVersion,
@@ -128,7 +128,7 @@ func (cxt *ConsensusContext) MakePayload(message ConsensusMessage) *msg.Consensu
 }
 
 func (cxt *ConsensusContext) MakePrepareRequest() *msg.ConsensusPayload {
-	log.Trace()
+	log.Debug()
 	preReq := &PrepareRequest{
 		Nonce:                  cxt.Nonce,
 		NextMiner:              cxt.NextMiner,
@@ -141,7 +141,7 @@ func (cxt *ConsensusContext) MakePrepareRequest() *msg.ConsensusPayload {
 }
 
 func (cxt *ConsensusContext) MakePrepareResponse(signature []byte) *msg.ConsensusPayload {
-	log.Trace()
+	log.Debug()
 	preRes := &PrepareResponse{
 		Signature: signature,
 	}
@@ -150,7 +150,7 @@ func (cxt *ConsensusContext) MakePrepareResponse(signature []byte) *msg.Consensu
 }
 
 func (cxt *ConsensusContext) GetSignaturesCount() (count int) {
-	log.Trace()
+	log.Debug()
 	count = 0
 	for _, sig := range cxt.Signatures {
 		if sig != nil {
@@ -161,7 +161,7 @@ func (cxt *ConsensusContext) GetSignaturesCount() (count int) {
 }
 
 func (cxt *ConsensusContext) GetTransactionList() []*tx.Transaction {
-	log.Trace()
+	log.Debug()
 	if cxt.txlist == nil {
 		cxt.txlist = []*tx.Transaction{}
 		for _, TX := range cxt.Transactions {
@@ -185,7 +185,7 @@ func (cxt *ConsensusContext) GetStateDetail() string {
 }
 
 func (cxt *ConsensusContext) GetTXByHashes() []*tx.Transaction {
-	log.Trace()
+	log.Debug()
 	TXs := []*tx.Transaction{}
 	var i int
 	var j int
@@ -200,7 +200,7 @@ func (cxt *ConsensusContext) GetTXByHashes() []*tx.Transaction {
 }
 
 func (cxt *ConsensusContext) CheckTxHashesExist() bool {
-	log.Trace()
+	log.Debug()
 	for _, hash := range cxt.TransactionHashes {
 		if _, ok := cxt.Transactions[hash]; !ok {
 			return false
@@ -210,7 +210,7 @@ func (cxt *ConsensusContext) CheckTxHashesExist() bool {
 }
 
 func (cxt *ConsensusContext) Reset(client cl.Client, localNode net.Neter) {
-	log.Trace()
+	log.Debug()
 	cxt.State = Initial
 	cxt.PrevHash = ledger.DefaultLedger.Blockchain.CurrentBlockHash()
 	cxt.Height = ledger.DefaultLedger.Blockchain.BlockHeight + 1

--- a/consensus/dbft/consensusMessage.go
+++ b/consensus/dbft/consensusMessage.go
@@ -22,7 +22,7 @@ type ConsensusMessageData struct {
 }
 
 func DeserializeMessage(data []byte) (ConsensusMessage, error) {
-	log.Trace()
+	log.Debug()
 	msgType := ConsensusMessageType(data[0])
 
 	r := bytes.NewReader(data)
@@ -61,7 +61,7 @@ func DeserializeMessage(data []byte) (ConsensusMessage, error) {
 }
 
 func (cd *ConsensusMessageData) Serialize(w io.Writer) {
-	log.Trace()
+	log.Debug()
 	//ConsensusMessageType
 	w.Write([]byte{byte(cd.Type)})
 
@@ -72,7 +72,7 @@ func (cd *ConsensusMessageData) Serialize(w io.Writer) {
 
 //read data to reader
 func (cd *ConsensusMessageData) Deserialize(r io.Reader) error {
-	log.Trace()
+	log.Debug()
 	//ConsensusMessageType
 	var msgType [1]byte
 	_, err := io.ReadFull(r, msgType[:])

--- a/consensus/dbft/prepareRequest.go
+++ b/consensus/dbft/prepareRequest.go
@@ -21,7 +21,7 @@ type PrepareRequest struct {
 }
 
 func (pr *PrepareRequest) Serialize(w io.Writer) error {
-	log.Trace()
+	log.Debug()
 	pr.msgData.Serialize(w)
 	err := ser.WriteVarUint(w, pr.Nonce)
 	if err != nil {
@@ -83,7 +83,7 @@ func (pr *PrepareRequest) Serialize(w io.Writer) error {
 
 //read data to reader
 func (pr *PrepareRequest) Deserialize(r io.Reader) error {
-	log.Trace()
+	log.Debug()
 	pr.msgData = ConsensusMessageData{}
 	pr.msgData.Deserialize(r)
 	pr.Nonce, _ = ser.ReadVarUint(r, 0)
@@ -149,16 +149,16 @@ func (pr *PrepareRequest) Deserialize(r io.Reader) error {
 }
 
 func (pr *PrepareRequest) Type() ConsensusMessageType {
-	log.Trace()
+	log.Debug()
 	return pr.ConsensusMessageData().Type
 }
 
 func (pr *PrepareRequest) ViewNumber() byte {
-	log.Trace()
+	log.Debug()
 	return pr.msgData.ViewNumber
 }
 
 func (pr *PrepareRequest) ConsensusMessageData() *ConsensusMessageData {
-	log.Trace()
+	log.Debug()
 	return &(pr.msgData)
 }

--- a/consensus/dbft/prepareResponse.go
+++ b/consensus/dbft/prepareResponse.go
@@ -12,7 +12,7 @@ type PrepareResponse struct {
 }
 
 func (pres *PrepareResponse) Serialize(w io.Writer) error {
-	log.Trace()
+	log.Debug()
 	pres.msgData.Serialize(w)
 	w.Write(pres.Signature)
 	return nil
@@ -20,7 +20,7 @@ func (pres *PrepareResponse) Serialize(w io.Writer) error {
 
 //read data to reader
 func (pres *PrepareResponse) Deserialize(r io.Reader) error {
-	log.Trace()
+	log.Debug()
 	err := pres.msgData.Deserialize(r)
 	if err != nil {
 		return err
@@ -35,16 +35,16 @@ func (pres *PrepareResponse) Deserialize(r io.Reader) error {
 }
 
 func (pres *PrepareResponse) Type() ConsensusMessageType {
-	log.Trace()
+	log.Debug()
 	return pres.ConsensusMessageData().Type
 }
 
 func (pres *PrepareResponse) ViewNumber() byte {
-	log.Trace()
+	log.Debug()
 	return pres.msgData.ViewNumber
 }
 
 func (pres *PrepareResponse) ConsensusMessageData() *ConsensusMessageData {
-	log.Trace()
+	log.Debug()
 	return &(pres.msgData)
 }

--- a/core/contract/contractContext.go
+++ b/core/contract/contractContext.go
@@ -25,7 +25,7 @@ type ContractContext struct {
 }
 
 func NewContractContext(data sig.SignableData) *ContractContext {
-	log.Trace()
+	log.Debug()
 	programHashes, _ := data.GetProgramHashes() //TODO: check error
 	log.Debug("programHashes= ", programHashes)
 	log.Debug("hashLen := len(programHashes) ", len(programHashes))
@@ -41,7 +41,7 @@ func NewContractContext(data sig.SignableData) *ContractContext {
 }
 
 func (cxt *ContractContext) Add(contract *Contract, index int, parameter []byte) error {
-	log.Trace()
+	log.Debug()
 	i := cxt.GetIndex(contract.ProgramHash)
 	if i < 0 {
 		return errors.New("Program Hash is not exist.")
@@ -57,9 +57,9 @@ func (cxt *ContractContext) Add(contract *Contract, index int, parameter []byte)
 }
 
 func (cxt *ContractContext) AddContract(contract *Contract, pubkey *crypto.PubKey, parameter []byte) error {
-	log.Trace()
+	log.Debug()
 	if contract.GetType() == MultiSigContract {
-		log.Trace()
+		log.Debug()
 		// add multi sig contract
 
 		log.Debug("Multi Sig: contract.ProgramHash:", contract.ProgramHash)
@@ -110,7 +110,7 @@ func (cxt *ContractContext) AddContract(contract *Contract, pubkey *crypto.PubKe
 
 	} else {
 		//add non multi sig contract
-		log.Trace()
+		log.Debug()
 		index := -1
 		for i := 0; i < len(contract.Parameters); i++ {
 			if contract.Parameters[i] == Signature {
@@ -221,7 +221,7 @@ func (cxt *ContractContext) GetIndex(programHash Uint160) int {
 }
 
 func (cxt *ContractContext) GetPrograms() []*pg.Program {
-	log.Trace()
+	log.Debug()
 	//log.Debug("!cxt.IsCompleted()=",!cxt.IsCompleted())
 	//log.Debug(cxt.Codes)
 	//log.Debug(cxt.Parameters)

--- a/core/ledger/blockchain.go
+++ b/core/ledger/blockchain.go
@@ -41,7 +41,7 @@ func NewBlockchainWithGenesisBlock() (*Blockchain, error) {
 }
 
 func (bc *Blockchain) AddBlock(block *Block) error {
-	log.Trace()
+	log.Debug()
 	bc.mutex.Lock()
 	defer bc.mutex.Unlock()
 
@@ -74,7 +74,7 @@ func (bc *Blockchain) GetHeader(hash Uint256) (*Header, error) {
 }
 
 func (bc *Blockchain) SaveBlock(block *Block) error {
-	log.Trace()
+	log.Debug()
 	log.Info("block hash ", block.Hash())
 	err := DefaultLedger.Store.SaveBlock(block, DefaultLedger)
 	if err != nil {

--- a/core/signature/signature.go
+++ b/core/signature/signature.go
@@ -28,7 +28,7 @@ type SignableData interface {
 }
 
 func SignBySigner(data SignableData, signer Signer) ([]byte, error) {
-	log.Trace()
+	log.Debug()
 	//fmt.Println("data",data)
 	rtx, err := Sign(data, signer.PrivKey())
 	if err != nil {

--- a/core/store/LevelDBStore/LevelDBStore.go
+++ b/core/store/LevelDBStore/LevelDBStore.go
@@ -454,7 +454,7 @@ func (bd *LevelDBStore) GetAsset(hash Uint256) (*Asset, error) {
 }
 
 func (bd *LevelDBStore) GetTransaction(hash Uint256) (*tx.Transaction, error) {
-	log.Trace()
+	log.Debug()
 	log.Debug(fmt.Sprintf("GetTransaction Hash: %x\n", hash))
 
 	t := new(tx.Transaction)

--- a/net/httpjsonrpc/RPCserver.go
+++ b/net/httpjsonrpc/RPCserver.go
@@ -8,7 +8,7 @@ import (
 )
 
 func StartRPCServer() {
-	log.Trace()
+	log.Debug()
 	http.HandleFunc("/", Handle)
 
 	HandleFunc("getbestblockhash", getBestBlockHash)

--- a/net/httpjsonrpc/localServer.go
+++ b/net/httpjsonrpc/localServer.go
@@ -13,7 +13,7 @@ const (
 )
 
 func StartLocalServer() {
-	log.Trace()
+	log.Debug()
 	http.HandleFunc(LocalDir, Handle)
 
 	HandleFunc("getneighbor", getNeighbor)

--- a/net/message/address.go
+++ b/net/message/address.go
@@ -88,7 +88,7 @@ func (msg addrReq) Verify(buf []byte) error {
 }
 
 func (msg addrReq) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	// lock
 	var addrstr []NodeAddr
 	var count uint64
@@ -161,7 +161,7 @@ func (msg addr) Verify(buf []byte) error {
 }
 
 func (msg addr) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	for _, v := range msg.nodeAddrs {
 		var ip net.IP
 		ip = v.IpAddr[:]

--- a/net/message/block.go
+++ b/net/message/block.go
@@ -25,7 +25,7 @@ type block struct {
 }
 
 func (msg block) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 
 	log.Debug("RX block message")
 
@@ -39,7 +39,7 @@ func (msg block) Handle(node Noder) error {
 }
 
 func (msg dataReq) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	reqtype := common.InventoryType(msg.dataType)
 	hash := msg.hash
 	switch reqtype {
@@ -80,7 +80,7 @@ func NewBlockFromHash(hash common.Uint256) (*ledger.Block, error) {
 }
 
 func NewBlock(bk *ledger.Block) ([]byte, error) {
-	log.Trace()
+	log.Debug()
 	var msg block
 	msg.blk = *bk
 	msg.msgHdr.Magic = NETMAGIC

--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -118,7 +118,7 @@ blkHdrErr:
 }
 
 func (msg headersReq) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	// lock
 	var startHash [HASHLEN]byte
 	var stopHash [HASHLEN]byte
@@ -169,7 +169,7 @@ func ReqBlkHdrFromOthers(node Noder) {
 }
 
 func (msg blkHeader) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	node.StopRetryTimer()
 	err := ledger.DefaultLedger.Store.AddHeaders(msg.blkHdr, ledger.DefaultLedger)
 	if err != nil {

--- a/net/message/consensus.go
+++ b/net/message/consensus.go
@@ -52,7 +52,7 @@ func (cp *ConsensusPayload) InvertoryType() common.InventoryType {
 }
 
 func (cp *ConsensusPayload) GetProgramHashes() ([]common.Uint160, error) {
-	log.Trace()
+	log.Debug()
 
 	if ledger.DefaultLedger == nil {
 		return nil, errors.New("The Default ledger not exists.")
@@ -105,7 +105,7 @@ func (cp *ConsensusPayload) GetMessage() []byte {
 }
 
 func (msg consensus) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 
 	node.LocalNode().GetEvent("consensus").Notify(events.EventNewInventory, &msg.cons)
 	return nil
@@ -165,7 +165,7 @@ func (msg *consensus) Serialization() ([]byte, error) {
 }
 
 func (cp *ConsensusPayload) DeserializeUnsigned(r io.Reader) error {
-	log.Trace()
+	log.Debug()
 	var err error
 	cp.Version, err = serialization.ReadUint32(r)
 	if err != nil {
@@ -213,12 +213,12 @@ func (cp *ConsensusPayload) DeserializeUnsigned(r io.Reader) error {
 	}
 	cp.Owner = pk
 
-	log.Trace()
+	log.Debug()
 	return nil
 }
 
 func (cp *ConsensusPayload) Deserialize(r io.Reader) error {
-	log.Trace()
+	log.Debug()
 	err := cp.DeserializeUnsigned(r)
 
 	pg := new(program.Program)
@@ -232,7 +232,7 @@ func (cp *ConsensusPayload) Deserialize(r io.Reader) error {
 }
 
 func (msg *consensus) Deserialization(p []byte) error {
-	log.Trace()
+	log.Debug()
 	buf := bytes.NewBuffer(p)
 	err := binary.Read(buf, binary.LittleEndian, &(msg.msgHdr))
 	err = msg.cons.Deserialize(buf)
@@ -240,7 +240,7 @@ func (msg *consensus) Deserialization(p []byte) error {
 }
 
 func NewConsensus(cp *ConsensusPayload) ([]byte, error) {
-	log.Trace()
+	log.Debug()
 	var msg consensus
 	msg.msgHdr.Magic = NETMAGIC
 	cmd := "consensus"

--- a/net/message/inventory.go
+++ b/net/message/inventory.go
@@ -69,7 +69,7 @@ func (msg blocksReq) Verify(buf []byte) error {
 }
 
 func (msg blocksReq) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	log.Debug("handle blocks request")
 	var starthash common.Uint256
 	var stophash common.Uint256
@@ -112,7 +112,7 @@ func (msg Inv) Verify(buf []byte) error {
 }
 
 func (msg Inv) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	var id common.Uint256
 	str := hex.EncodeToString(msg.P.Blk)
 	fmt.Printf("The inv type: 0x%x block len: %d, %s\n",

--- a/net/message/message.go
+++ b/net/message/message.go
@@ -301,7 +301,7 @@ func (hdr msgHdr) Serialization() ([]byte, error) {
 }
 
 func (hdr msgHdr) Handle(n Noder) error {
-	log.Trace()
+	log.Debug()
 	// TBD
 	return nil
 }

--- a/net/message/transaction.go
+++ b/net/message/transaction.go
@@ -30,7 +30,7 @@ type trn struct {
 }
 
 func (msg trn) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	log.Debug("RX Transaction message")
 	tx := &msg.txn
 	if !node.LocalNode().ExistedID(tx.Hash()) {
@@ -107,7 +107,7 @@ func NewTxnFromHash(hash common.Uint256) (*transaction.Transaction, error) {
 	return txn, nil
 }
 func NewTxn(txn *transaction.Transaction) ([]byte, error) {
-	log.Trace()
+	log.Debug()
 	var msg trn
 
 	msg.msgHdr.Magic = NETMAGIC

--- a/net/message/verack.go
+++ b/net/message/verack.go
@@ -51,7 +51,7 @@ func NewVerack() ([]byte, error) {
  */
 // TODO The process should be adjusted based on above table
 func (msg verACK) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 
 	t := time.Now()
 	s := node.GetState()

--- a/net/message/version.go
+++ b/net/message/version.go
@@ -35,7 +35,7 @@ func (msg *version) init(n Noder) {
 }
 
 func NewVersion(n Noder) ([]byte, error) {
-	log.Trace()
+	log.Debug()
 	var msg version
 
 	msg.P.Version = n.Version()
@@ -146,7 +146,7 @@ func (msg *version) Deserialization(p []byte) error {
  * |------------------------------------------------------------------------
  */
 func (msg version) Handle(node Noder) error {
-	log.Trace()
+	log.Debug()
 	localNode := node.LocalNode()
 
 	// Exclude the node itself

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -149,7 +149,7 @@ func (n *node) initConnection() {
 }
 
 func initNonTlsListen() (net.Listener, error) {
-	log.Trace()
+	log.Debug()
 	listener, err := net.Listen("tcp", ":"+strconv.Itoa(Parameters.NodePort))
 	if err != nil {
 		log.Error("Error listening\n", err.Error())
@@ -207,7 +207,7 @@ func parseIPaddr(s string) (string, error) {
 }
 
 func (node *node) Connect(nodeAddr string) error {
-	log.Trace()
+	log.Debug()
 	isTls := Parameters.IsTLS
 	var conn net.Conn
 	var err error
@@ -244,7 +244,7 @@ func (node *node) Connect(nodeAddr string) error {
 }
 
 func NonTLSDial(nodeAddr string) (net.Conn, error) {
-	log.Trace()
+	log.Debug()
 	conn, err := net.Dial("tcp", nodeAddr)
 	if err != nil {
 		log.Error("Error dialing\n", err.Error())
@@ -286,7 +286,7 @@ func TLSDial(nodeAddr string) (net.Conn, error) {
 }
 
 func (node node) Tx(buf []byte) {
-	log.Trace()
+	log.Debug()
 	str := hex.EncodeToString(buf)
 	log.Debug(fmt.Sprintf("TX buf length: %d\n%s", len(buf), str))
 

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -188,7 +188,7 @@ func (node *node) UpdateTime(t time.Time) {
 }
 
 func (node *node) Xmit(inv common.Inventory) error {
-	log.Trace()
+	log.Debug()
 	var buffer []byte
 	var err error
 

--- a/net/node/transactionPool.go
+++ b/net/node/transactionPool.go
@@ -91,7 +91,7 @@ func (node *node) SynchronizeTxnPool() {
 func (txnPool *TXNPool) CleanSubmittedTransactions(block *ledger.Block) error {
 	txnPool.Lock()
 	defer txnPool.Unlock()
-	log.Trace()
+	log.Debug()
 
 	err := txnPool.CleanTxnPool(block.Transactions)
 	if err != nil {


### PR DESCRIPTION
promoted to the hightest debug print level, it *should be only*
used for local tempory testing, and never be existed in the main
branch.

The log.Debug with lowest priority can be used to instead the previous
trace function to print some general trace info