### PR TITLE
fix block root calculation (#730)

### DIFF
--- a/consensus/dbft/consensus_context.go
+++ b/consensus/dbft/consensus_context.go
@@ -100,7 +100,7 @@ func (ctx *ConsensusContext) MakeHeader() *types.Block {
 			txHash = append(txHash, t.Hash())
 		}
 		txRoot := common.ComputeMerkleRoot(txHash)
-		blockRoot := ledger.DefLedger.GetBlockRootWithNewTxRoot(txRoot)
+		blockRoot := ledger.DefLedger.GetBlockRootWithNewTxRoots(ctx.Height, []common.Uint256{txRoot})
 		header := &types.Header{
 			Version:          ContextVersion,
 			PrevBlockHash:    ctx.PrevHash,

--- a/consensus/solo/solo.go
+++ b/consensus/solo/solo.go
@@ -197,7 +197,7 @@ func (self *SoloService) makeBlock() (*types.Block, error) {
 	}
 	txRoot := common.ComputeMerkleRoot(txHash)
 
-	blockRoot := ledger.DefLedger.GetBlockRootWithNewTxRoot(txRoot)
+	blockRoot := ledger.DefLedger.GetBlockRootWithNewTxRoots(height+1, []common.Uint256{txRoot})
 	header := &types.Header{
 		Version:          ContextVersion,
 		PrevBlockHash:    prevHash,

--- a/consensus/vbft/msg_builder.go
+++ b/consensus/vbft/msg_builder.go
@@ -182,8 +182,14 @@ func (self *Server) constructBlock(blkNum uint32, prevBlkHash common.Uint256, tx
 	for _, t := range txs {
 		txHash = append(txHash, t.Hash())
 	}
+	lastBlock, err := self.chainStore.GetBlock(blkNum - 1)
+	if err != nil {
+		log.Errorf("constructBlock getlastblock err:%s,blknum:%d", err, blkNum-1)
+		return nil, err
+	}
+
 	txRoot := common.ComputeMerkleRoot(txHash)
-	blockRoot := ledger.DefLedger.GetBlockRootWithNewTxRoot(txRoot)
+	blockRoot := ledger.DefLedger.GetBlockRootWithNewTxRoots(lastBlock.Block.Header.Height, []common.Uint256{lastBlock.Block.Header.TransactionsRoot, txRoot})
 
 	blkHeader := &types.Header{
 		PrevBlockHash:    prevBlkHash,

--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -84,8 +84,8 @@ func (self *Ledger) GetStateMerkleRoot(height uint32) (result common.Uint256, er
 	return self.ldgStore.GetStateMerkleRoot(height)
 }
 
-func (self *Ledger) GetBlockRootWithNewTxRoot(txRoot common.Uint256) common.Uint256 {
-	return self.ldgStore.GetBlockRootWithNewTxRoot(txRoot)
+func (self *Ledger) GetBlockRootWithNewTxRoots(startHeight uint32, txRoots []common.Uint256) common.Uint256 {
+	return self.ldgStore.GetBlockRootWithNewTxRoots(startHeight, txRoots)
 }
 
 func (self *Ledger) GetBlockByHeight(height uint32) (*types.Block, error) {

--- a/core/store/ledgerstore/state_store.go
+++ b/core/store/ledgerstore/state_store.go
@@ -382,8 +382,8 @@ func (self *StateStore) GetStateMerkleRootWithNewHash(writeSetHash common.Uint25
 	return self.deltaMerkleTree.GetRootWithNewLeaf(writeSetHash)
 }
 
-func (self *StateStore) GetBlockRootWithNewTxRoot(txRoot common.Uint256) common.Uint256 {
-	return self.merkleTree.GetRootWithNewLeaf(txRoot)
+func (self *StateStore) GetBlockRootWithNewTxRoots(txRoots []common.Uint256) common.Uint256 {
+	return self.merkleTree.GetRootWithNewLeaves(txRoots)
 }
 
 func (self *StateStore) genBlockMerkleTreeKey() []byte {

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -57,7 +57,7 @@ type LedgerStore interface {
 	GetTransaction(txHash common.Uint256) (*types.Transaction, uint32, error)
 	IsContainBlock(blockHash common.Uint256) (bool, error)
 	IsContainTransaction(txHash common.Uint256) (bool, error)
-	GetBlockRootWithNewTxRoot(txRoot common.Uint256) common.Uint256
+	GetBlockRootWithNewTxRoots(startHeight uint32, txRoots []common.Uint256) common.Uint256
 	GetMerkleProof(m, n uint32) ([]common.Uint256, error)
 	GetContractState(contractHash common.Address) (*payload.DeployCode, error)
 	GetBookkeeperState() (*states.BookkeeperState, error)

--- a/merkle/merkle_tree.go
+++ b/merkle/merkle_tree.go
@@ -125,6 +125,28 @@ func (self *CompactMerkleTree) GetRootWithNewLeaf(newLeaf common.Uint256) common
 	return root
 }
 
+// clone except internal hash storage
+func (self *CompactMerkleTree) cloneMem() CompactMerkleTree {
+	temp := CompactMerkleTree{mintree_h: self.mintree_h, hasher: self.hasher, hashStore: nil,
+		rootHash: self.rootHash, treeSize: self.treeSize,
+	}
+	temp.hashes = make([]common.Uint256, len(self.hashes))
+	for i, h := range self.hashes {
+		temp.hashes[i] = h
+	}
+
+	return temp
+}
+
+func (self *CompactMerkleTree) GetRootWithNewLeaves(newLeaf []common.Uint256) common.Uint256 {
+	tree := self.cloneMem()
+	for _, h := range newLeaf {
+		tree.AppendHash(h)
+	}
+
+	return tree.Root()
+}
+
 // Append appends a leaf to the merkle tree and returns the audit path
 func (self *CompactMerkleTree) Append(leafv []byte) []common.Uint256 {
 	leaf := self.hasher.hash_leaf(leafv)

--- a/merkle/merkle_tree_test.go
+++ b/merkle/merkle_tree_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/ontio/dad-go/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMerkleLeaf3(t *testing.T) {
@@ -62,6 +63,20 @@ func TestMerkleLeaf3(t *testing.T) {
 		}
 	}
 
+}
+
+func TestCompactMerkleTree_GetRootWithNewLeaves(t *testing.T) {
+	N := 1000
+	tree1 := NewTree(0, nil, nil)
+	tree2 := NewTree(0, nil, nil)
+	leaves := make([]common.Uint256, N)
+	for i := 0; i < N; i++ {
+		leaves[i][:][0] = byte(i)
+		hash := leaves[i]
+		assert.Equal(t, tree1.GetRootWithNewLeaf(hash), tree2.GetRootWithNewLeaves([]common.Uint256{hash}))
+		tree1.AppendHash(hash)
+		tree2.AppendHash(hash)
+	}
 }
 
 func TestMerkle(t *testing.T) {


### PR DESCRIPTION
* check block root when persist block

* add GetBlockRootWithNewTxRoots function

* optimize calculate blockRoot and optimize init load vbft peerInfo

* make GetBlockRootWithNewTxRoots more robust

* fix genesis block persist